### PR TITLE
Migrate blog posts to markdown and enable publishing filters

### DIFF
--- a/content/posts/getting-total-files-in-a-unix-system.md
+++ b/content/posts/getting-total-files-in-a-unix-system.md
@@ -1,0 +1,35 @@
+---
+title: "Getting the Total Number of Files/Folders in a Unix/Linux System Directory"
+category: "Unix"
+date: "2020-05-15"
+readTime: "1 min read"
+excerpt: "A quick command-line trick to count the number of files or folders in any directory using ls and wc."
+status: "published"
+---
+
+There are times when we want to count the number of the files or folders in a directory. We can use the below trick to get that information.
+
+## Command
+
+```bash
+ls -1 | wc -l
+```
+
+## Explanation
+
+The `ls` command will **list** all the files/folders in the current directory. When `-1` is added to the option, it lists one file/folder per line as below:
+
+```bash
+ls -1
+foo.txt
+bar.txt
+```
+
+The `wc` command is the **word count** command in a Unix system. One of its options is `-l`, which counts the number of lines.
+
+Thus, if we pipe the above two commands, the output of `ls -1` command (which lists the files/folders in the current directory) is taken as the input to the `wc -l` command (which counts the number of lines). Assuming `foo.txt` and `bar.txt` are the only files in the directory, the output of the above command will result as:
+
+```bash
+ls -1 | wc -l
+2
+```

--- a/content/posts/install-oh-my-zsh.md
+++ b/content/posts/install-oh-my-zsh.md
@@ -1,0 +1,77 @@
+---
+title: "iTerm2 + Oh-My-Zsh + PowerLevel10k"
+category: "Terminal"
+date: "2020-06-06"
+readTime: "5 min read"
+excerpt: "A complete guide to configuring your macOS terminal with iTerm2, Oh-My-Zsh, and the PowerLevel10k theme for a beautiful and productive setup."
+status: "published"
+---
+
+Do you want your terminal to look sleek and modern? Follow this guide to configure your macOS terminal with iTerm2, Oh-My-Zsh, and the PowerLevel10k theme.
+
+## Install iTerm2
+
+We will use **brew** to install iTerm2.
+
+```bash
+brew cask install iterm2
+```
+
+## Installing Oh-My-Zsh
+
+### Prerequisites
+
+You need to have a zsh-shell installed in your system. To check which zsh version you have, type the following command:
+
+```bash
+zsh --version
+```
+
+You should see something like:
+
+```
+zsh 5.7.1 (x86_64-apple-darwin19.0)
+```
+
+If you don't have zsh installed, you can install it on your Mac:
+
+```bash
+brew install zsh
+chsh -s /usr/local/bin/zsh
+```
+
+### Install Oh-My-Zsh
+
+You can install Oh-My-Zsh using curl:
+
+```bash
+sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+```
+
+## Installing PowerLevel10k
+
+1. Clone the theme repository:
+
+```bash
+git clone --depth=1 https://github.com/romkatv/powerlevel10k.git ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/themes/powerlevel10k
+```
+
+2. Open **.zshrc** for editing: `nano ~/.zshrc`
+
+3. Update the theme:
+
+```bash
+ZSH_THEME="powerlevel10k/powerlevel10k"
+```
+
+4. Save and exit, then run `source ~/.zshrc` for changes to take effect.
+
+5. Quit and reopen iTerm2.
+
+## Configure PowerLevel10k
+
+When you reopen iTerm2, you should be taken directly to the screen for configuring PowerLevel10k. If the interactive configuration doesn't show up, type `p10k configure` to bring up the wizard.
+
+> **Note:** PowerLevel10k requires the Meslo Nerd Font patch, so be sure to accept when prompted.
+
+Navigate through the interactive window and select the options based on your preference.

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -1,3 +1,9 @@
+import fs from "fs";
+import path from "path";
+import matter from "gray-matter";
+
+const postsDirectory = path.join(process.cwd(), "content/posts");
+
 export interface Post {
   slug: string;
   title: string;
@@ -6,127 +12,59 @@ export interface Post {
   readTime: string;
   excerpt: string;
   content: string;
+  status: "draft" | "published";
 }
 
-export const posts: Post[] = [
-  {
-    slug: "getting-total-files-in-a-unix-system",
-    title: "Getting the Total Number of Files/Folders in a Unix/Linux System Directory",
-    category: "Unix",
-    date: "May 15, 2020",
-    readTime: "1 min read",
-    excerpt:
-      "A quick command-line trick to count the number of files or folders in any directory using ls and wc.",
-    content: `There are times when we want to count the number of the files or folders in a directory. We can use the below trick to get that information.
+function formatDate(dateStr: string): string {
+  const date = new Date(dateStr);
+  return date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
 
-## Command
+function parsePost(slug: string): Post {
+  const fullPath = path.join(postsDirectory, `${slug}.md`);
+  const fileContents = fs.readFileSync(fullPath, "utf8");
+  const { data, content } = matter(fileContents);
 
-\`\`\`bash
-ls -1 | wc -l
-\`\`\`
-
-## Explanation
-
-The \`ls\` command will **list** all the files/folders in the current directory. When \`-1\` is added to the option, it lists one file/folder per line as below:
-
-\`\`\`bash
-ls -1
-foo.txt
-bar.txt
-\`\`\`
-
-The \`wc\` command is the **word count** command in a Unix system. One of its options is \`-l\`, which counts the number of lines.
-
-Thus, if we pipe the above two commands, the output of \`ls -1\` command (which lists the files/folders in the current directory) is taken as the input to the \`wc -l\` command (which counts the number of lines). Assuming \`foo.txt\` and \`bar.txt\` are the only files in the directory, the output of the above command will result as:
-
-\`\`\`bash
-ls -1 | wc -l
-2
-\`\`\``,
-  },
-  {
-    slug: "install-oh-my-zsh",
-    title: "iTerm2 + Oh-My-Zsh + PowerLevel10k",
-    category: "Terminal",
-    date: "Jun 6, 2020",
-    readTime: "5 min read",
-    excerpt:
-      "A complete guide to configuring your macOS terminal with iTerm2, Oh-My-Zsh, and the PowerLevel10k theme for a beautiful and productive setup.",
-    content: `Do you want your terminal to look sleek and modern? Follow this guide to configure your macOS terminal with iTerm2, Oh-My-Zsh, and the PowerLevel10k theme.
-
-## Install iTerm2
-
-We will use **brew** to install iTerm2.
-
-\`\`\`bash
-brew cask install iterm2
-\`\`\`
-
-## Installing Oh-My-Zsh
-
-### Prerequisites
-
-You need to have a zsh-shell installed in your system. To check which zsh version you have, type the following command:
-
-\`\`\`bash
-zsh --version
-\`\`\`
-
-You should see something like:
-
-\`\`\`
-zsh 5.7.1 (x86_64-apple-darwin19.0)
-\`\`\`
-
-If you don't have zsh installed, you can install it on your Mac:
-
-\`\`\`bash
-brew install zsh
-chsh -s /usr/local/bin/zsh
-\`\`\`
-
-### Install Oh-My-Zsh
-
-You can install Oh-My-Zsh using curl:
-
-\`\`\`bash
-sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
-\`\`\`
-
-## Installing PowerLevel10k
-
-1. Clone the theme repository:
-
-\`\`\`bash
-git clone --depth=1 https://github.com/romkatv/powerlevel10k.git \${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/themes/powerlevel10k
-\`\`\`
-
-2. Open **.zshrc** for editing: \`nano ~/.zshrc\`
-
-3. Update the theme:
-
-\`\`\`bash
-ZSH_THEME="powerlevel10k/powerlevel10k"
-\`\`\`
-
-4. Save and exit, then run \`source ~/.zshrc\` for changes to take effect.
-
-5. Quit and reopen iTerm2.
-
-## Configure PowerLevel10k
-
-When you reopen iTerm2, you should be taken directly to the screen for configuring PowerLevel10k. If the interactive configuration doesn't show up, type \`p10k configure\` to bring up the wizard.
-
-> **Note:** PowerLevel10k requires the Meslo Nerd Font patch, so be sure to accept when prompted.
-
-Navigate through the interactive window and select the options based on your preference.`,
-  },
-];
+  return {
+    slug,
+    title: data.title,
+    category: data.category,
+    date: formatDate(data.date),
+    readTime: data.readTime,
+    excerpt: data.excerpt,
+    content: content.trim(),
+    status: data.status || "draft",
+  };
+}
 
 export function getPostBySlug(slug: string): Post | undefined {
-  return posts.find((post) => post.slug === slug);
+  try {
+    const post = parsePost(slug);
+    return post.status === "published" ? post : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 export function getAllPosts(): Post[] {
+  if (!fs.existsSync(postsDirectory)) {
+    return [];
+  }
+
+  const fileNames = fs.readdirSync(postsDirectory);
+
+  const posts = fileNames
+    .filter((fileName) => fileName.endsWith(".md"))
+    .map((fileName) => {
+      const slug = fileName.replace(/\.md$/, "");
+      return parsePost(slug);
+    })
+    .filter((post) => post.status === "published")
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+
   return posts;
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "next": "^16",
     "react": "^19",
     "react-dom": "^19",
+    "gray-matter": "^4.0.3",
     "lucide-react": "^0.468.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
       lucide-react:
         specifier: ^0.468.0
         version: 0.468.0(react@19.2.4)
@@ -388,6 +391,9 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
   baseline-browser-mapping@2.9.19:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
     hasBin: true
@@ -416,12 +422,37 @@ packages:
     resolution: {integrity: sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==}
     engines: {node: '>=10.13.0'}
 
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  gray-matter@4.0.3:
+    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
+    engines: {node: '>=6.0'}
+
+  is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+    hasBin: true
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
 
   lightningcss-android-arm64@1.30.2:
     resolution: {integrity: sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==}
@@ -554,6 +585,10 @@ packages:
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
+  section-matter@1.0.0:
+    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
+    engines: {node: '>=4'}
+
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
@@ -565,6 +600,13 @@ packages:
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  strip-bom-string@1.0.0:
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
     engines: {node: '>=0.10.0'}
 
   styled-jsx@5.1.6:
@@ -837,6 +879,10 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
   baseline-browser-mapping@2.9.19: {}
 
   caniuse-lite@1.0.30001770: {}
@@ -858,9 +904,31 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.0
 
+  esprima@4.0.1: {}
+
+  extend-shallow@2.0.1:
+    dependencies:
+      is-extendable: 0.1.1
+
   graceful-fs@4.2.11: {}
 
+  gray-matter@4.0.3:
+    dependencies:
+      js-yaml: 3.14.2
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
+
+  is-extendable@0.1.1: {}
+
   jiti@2.6.1: {}
+
+  js-yaml@3.14.2:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
+  kind-of@6.0.3: {}
 
   lightningcss-android-arm64@1.30.2:
     optional: true
@@ -968,6 +1036,11 @@ snapshots:
 
   scheduler@0.27.0: {}
 
+  section-matter@1.0.0:
+    dependencies:
+      extend-shallow: 2.0.1
+      kind-of: 6.0.3
+
   semver@7.7.4:
     optional: true
 
@@ -1004,6 +1077,10 @@ snapshots:
     optional: true
 
   source-map-js@1.2.1: {}
+
+  sprintf-js@1.0.3: {}
+
+  strip-bom-string@1.0.0: {}
 
   styled-jsx@5.1.6(react@19.2.4):
     dependencies:


### PR DESCRIPTION
- Migrated blog posts to markdown files with structured frontmatter metadata.
- Updated the post module to support markdown parsing and dynamic content loading.
- Added logic to filter and display only published posts.
- Updated project configuration in `settings.json`.

[v0 Session](https://v0.app/chat/0YriIh9FV9w)